### PR TITLE
Lengen delay of the portal trap

### DIFF
--- a/src/main/java/net/kaikk/mc/gpp/PlayerEventHandler.java
+++ b/src/main/java/net/kaikk/mc/gpp/PlayerEventHandler.java
@@ -1483,7 +1483,7 @@ class PlayerEventHandler implements Listener {
 			// FEATURE: when players get trapped in a nether portal, send them
 			// back through to the other side
 			final CheckForPortalTrapTask task = new CheckForPortalTrapTask(player, event.getFrom());
-			GriefPreventionPlus.getInstance().getServer().getScheduler().scheduleSyncDelayedTask(GriefPreventionPlus.getInstance(), task, 100L);
+			GriefPreventionPlus.getInstance().getServer().getScheduler().scheduleSyncDelayedTask(GriefPreventionPlus.getInstance(), task, 600L);
 
 			// FEATURE: if the player teleporting doesn't have permission to
 			// build a nether portal and none already exists at the destination,


### PR DESCRIPTION
Similar to GriefPrevention commit https://github.com/BigScary/GriefPrevention/commit/1b0e88b0c12a5327f4193fa235593fd10ce5f959

The default portal trap delay of 5 seconds causes players with slower connections or computers to have a high chance of rebounding when using nether portals. 10 seconds is plenty for most settings but heavy modpacks can extend nether load times beyond that, so 30 seconds feels appropriate as a maximum. This value was used in another branch and seems fair for a relatively uncommon event.

